### PR TITLE
[DISCUSS] Add join function for symmetry

### DIFF
--- a/src/DssCdpManager.sol
+++ b/src/DssCdpManager.sol
@@ -22,7 +22,7 @@ contract PitLike {
     function frob(bytes32, bytes32, bytes32, bytes32, int256, int256) public;
 }
 
-contract JoinLike {
+contract AdapterLike {
     function exit(bytes32, address, uint) public;
 }
 
@@ -96,12 +96,12 @@ contract DssCdpManager {
     }
 
     function exit(
-        address join,
+        address adapter,
         bytes12 cdp,
         address guy,
         uint wad
     ) public note isAllowed(cdp) {
-        JoinLike(join).exit(getUrn(cdp), guy, wad);
+        AdapterLike(adapter).exit(getUrn(cdp), guy, wad);
     }
 
     function frob(

--- a/src/DssCdpManager.sol
+++ b/src/DssCdpManager.sol
@@ -95,6 +95,13 @@ contract DssCdpManager {
         urn = bytes32(uint(address(this)) * 2 ** (12 * 8) + uint96(cdp));
     }
 
+    function join(
+        address adapter,
+        bytes12 cdp,
+        uint wad
+    } public note {
+        AdapterLike(adapter).join(getUrn(cdp), wad);
+    }
     function exit(
         address adapter,
         bytes12 cdp,


### PR DESCRIPTION
This approach seems to have more symmetry. The proxy actions could still call the adapter directly, but I think this improves clarity and no/little added cost, and benefits someone who for whatever reason doesn't use the proxy actions