### PR TITLE
change allow function from bool to uint for improved gas

### DIFF
--- a/src/DssCdpManager.sol
+++ b/src/DssCdpManager.sol
@@ -84,7 +84,7 @@ contract DssCdpManager {
     mapping (
         address => mapping (
             uint => mapping (
-                address => bool
+                address => uint
             )
         )
     ) public allows;                            // Owner => CDPId => Allowed Addr => True/False
@@ -120,7 +120,7 @@ contract DssCdpManager {
     modifier isAllowed(
         uint cdp
     ) {
-        require(msg.sender == lads[cdp] || allows[lads[cdp]][cdp][msg.sender], "not-allowed");
+        require(msg.sender == lads[cdp] || allows[lads[cdp]][cdp][msg.sender] == 1, "not-allowed");
         _;
     }
 
@@ -136,7 +136,7 @@ contract DssCdpManager {
     function allow(
         uint cdp,
         address guy,
-        bool ok
+        uint ok
     ) public {
         allows[msg.sender][cdp][guy] = ok;
     }

--- a/src/DssCdpManager.t.sol
+++ b/src/DssCdpManager.t.sol
@@ -55,7 +55,7 @@ contract DssCdpManagerTest is DssDeployTestBase {
 
     function testTransferAllowed() public {
         uint cdp = manager.open("ETH");
-        manager.allow(cdp, address(user), true);
+        manager.allow(cdp, address(user), 1);
         user.doGive(manager, cdp, address(123));
         assertEq(manager.lads(cdp), address(123));
     }
@@ -67,15 +67,15 @@ contract DssCdpManagerTest is DssDeployTestBase {
 
     function testFailTransferNotAllowed2() public {
         uint cdp = manager.open("ETH");
-        manager.allow(cdp, address(user), true);
-        manager.allow(cdp, address(user), false);
+        manager.allow(cdp, address(user), 1);
+        manager.allow(cdp, address(user), 0);
         user.doGive(manager, cdp, address(123));
     }
 
     function testFailTransferNotAllowed3() public {
         uint cdp = manager.open("ETH");
         uint cdp2 = manager.open("ETH");
-        manager.allow(cdp2, address(user), true);
+        manager.allow(cdp2, address(user), 1);
         user.doGive(manager, cdp, address(123));
     }
 
@@ -266,7 +266,7 @@ contract DssCdpManagerTest is DssDeployTestBase {
         weth.deposit.value(1 ether)();
         weth.approve(address(ethJoin), 1 ether);
         ethJoin.join(manager.urns(cdp), 1 ether);
-        manager.allow(cdp, address(user), true);
+        manager.allow(cdp, address(user), 1);
         user.doFrob(manager, cdp, 1 ether, 50 ether);
         assertEq(vat.dai(manager.urns(cdp)), 50 ether * ONE);
     }


### PR DESCRIPTION
`dss/vat.sol` utilizes `uint` instead of `bool` for permissions.  This appears to save gas:
With `bool`
- writing transaction costs 43800 gas
- contract reading transaction costs 23670 gas

With `uint`
- writing transaction costs 43629 gas (-171)
- contract reading transaction costs 23662 gas (-8)

For example, this slightly reduces the cost of the test suite by 1248 gas:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/1408372/56315919-065eb680-6127-11e9-8ed4-3a69dffc8454.png">

It seems this would require a change to `dss-proxy-actions` as well ([PR](https://github.com/makerdao/dss-proxy-actions/pull/5)), but should not require any other smart contract changes and would provide a slight improvement in efficiency.