### PR TITLE
Adding standard erc721 functions [WIP]

### DIFF
--- a/src/DssCdpManager.sol
+++ b/src/DssCdpManager.sol
@@ -222,4 +222,71 @@ contract DssCdpManager is DSNote {
             toInt(art)
         );
     }
+
+    // ERC721 standard compatibility functions
+
+    function _checkOnERC721Received(
+        address from,
+        address to,
+        uint tokenId,
+        bytes memory data
+    ) internal returns (bool) {
+        uint size;
+        assembly { size := extcodesize(to) }
+
+        if (size == 0) {
+            return true;
+        }
+
+        return IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, data) ==
+                bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"));
+    }
+
+    function balanceOf(
+        address owner
+    ) external view returns (uint) {
+        return count[owner];
+    }
+
+    function ownerOf(
+        uint tokenId
+    ) external view returns (address) {
+        return owns[tokenId];
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint tokenId
+    ) public {
+        require(from == owns[tokenId], "from-not-owner");
+        give(tokenId, to);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint tokenId,
+        bytes memory data
+    ) public {
+        transferFrom(from, to, tokenId);
+        require(_checkOnERC721Received(from, to, tokenId, data), "not-onERC721Received");
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint tokenId
+    ) public {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+}
+
+contract IERC721Receiver {
+    function onERC721Received(
+        address,
+        address,
+        uint,
+        bytes memory
+    ) public returns (bytes4);
 }


### PR DESCRIPTION
Some things to discuss:

- Do we want the erc721 compatibility at all? I guess if we want the cdps are used as NFTs we should probably do it. Also it was one of the reasons to create the cdp manager.

- Approval works differently in the erc721 standard than how we implemented in the manager. IMO manager one is more flexible.
So we could opt to force the erc721 one in the manager or just keep the actual one and avoid the approval methods from erc721. I think they are probably not the most important ones.
If cdps are being integrated as NFTs from some third platforms I guess, in general, they will just need to access to `transferFrom` and `safeTransferFrom` functions.