### PR TITLE
Index cdp param of NewCdp event

### DIFF
--- a/src/DssCdpManager.sol
+++ b/src/DssCdpManager.sol
@@ -48,7 +48,7 @@ contract DssCdpManager is LibNote {
         uint next;
     }
 
-    event NewCdp(address indexed usr, address indexed own, uint cdp);
+    event NewCdp(address indexed usr, address indexed own, uint indexed cdp);
 
     modifier cdpAllowed(
         uint cdp


### PR DESCRIPTION
Currently there’s no good way to lookup a ManagedCdp creation event via `getPastLogs` using just its id.
(UrnHandler would have worked, but the 2 indexed event params `usr` and `own` are actually the DSProxy address.)
This change would allow the lookup of a `NewCdp` event using just its id via a topic.